### PR TITLE
Styling tweaks and FF bugfixes

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -152,6 +152,7 @@ ion-icon {
 }
 
 .risk-popover .popover-content{
+        min-height: 88vh;
         min-width: 80vw;
         position: relative;
         bottom: 0 !important;

--- a/src/components/risk-popover/risk-popover.html
+++ b/src/components/risk-popover/risk-popover.html
@@ -6,10 +6,10 @@
   <div class="axis-labels-more-info">
     <h6 class="toggle-header">View Rating Descriptions</h6>
     <div id="buttons-container">
-      <button ion-button color="buttonBlue" id="ratings-toggle1" (click) = "toggleDescriptionTable()">
+      <button ion-button color="buttonBlue" id="ratings-toggle1" (click) = "toggleDescriptionTable('likelihood')">
         Likelihood
       </button>
-      <button ion-button color="buttonBlue" id="ratings-toggle2" (click) = "toggleDescriptionTable()">
+      <button ion-button color="buttonBlue" id="ratings-toggle2" (click) = "toggleDescriptionTable('consequence')">
         Consequence
       </button>
     </div>
@@ -85,7 +85,7 @@
         <th class="consequence-cell">Critical</th>
         <th class="consequence-cell">Catastrophic</th>
       </tr>
-      <tr class="consequence-row">
+      <tr id="con-label" class="consequence-row">
         <th class="empty-cell"></th>
         <th class="empty-cell"></th>
         <th id="empty-consequence-cell-left"></th>

--- a/src/components/risk-popover/risk-popover.scss
+++ b/src/components/risk-popover/risk-popover.scss
@@ -5,6 +5,7 @@ risk-popover {
 	$likelihood-cell-width: 6vw;
 	$color-coding-key-width: 7.5em;
 	%digit-cell{
+    background-clip: padding-box;
 		width: $basic-cell-width;
 		font-weight: $cell-font-weight;
 		border: solid black 2px;
@@ -62,6 +63,7 @@ risk-popover {
 		width: $likelihood-cell-width;
 		font-weight: $cell-font-weight;
 		border: solid black 2px;
+    text-align: center;
 		@media (max-width: 460px) {
 			width: 15vw;
 			font-size: 10px;
@@ -115,24 +117,27 @@ risk-popover {
 		overflow: visible;
 		white-space: nowrap;
 		border: none;
-		border-bottom: solid black 2px;
+//		border-bottom: solid black 2px;
 	}
 	.color-coding{
 		float: left;
 		width: $color-coding-key-width;
-		border: solid black 1px;
+		//border: solid black 1px;
 		clear: both;
 	}
 	.color-coding > div {
 		@extend %color-code-cell;
 	}
 	#color-code-cell1{
+    border: 2px solid black;
 		background-color: green;
 	}
 	#color-code-cell2{
+    border: 2px solid black;
 		background-color: yellow;
 	}
 	#color-code-cell3{
+    border: 2px solid black;
 		background-color: red;
 	}
 	.axis-labels-more-info {
@@ -171,6 +176,7 @@ risk-popover {
     width: 30vw;
 	}
 	.crit-table-row > th {
+    text-align: center;
 		font-weight: normal;
 	}
 	.crit-table-left-col {
@@ -223,6 +229,16 @@ risk-popover {
   #buttons-container {
     display: flex;
 
+  }
+
+  th {
+          text-align: center;
+  }
+
+  #con-label {
+          th {
+            border:none;
+          }
   }
 
 

--- a/src/components/risk-popover/risk-popover.ts
+++ b/src/components/risk-popover/risk-popover.ts
@@ -12,8 +12,8 @@ export class RiskPopoverComponent {
                 console.log(this.navParams.get('highlight'));
 		this.chartView = this.navParams.get('highlight');
 	}
-	toggleDescriptionTable(){
-    this.chartView = (<any>event).path[0].innerText.toLowerCase();
+	toggleDescriptionTable(type){
+    this.chartView = type
 		setTimeout(() => {
 		  this.chart = document.getElementsByClassName("criteria-table")[0];
 		  this.scrollTableToView();

--- a/src/pages/questions/questions.scss
+++ b/src/pages/questions/questions.scss
@@ -561,6 +561,8 @@ color: black;
 
 	$basic-cell-size: 4vw;
 	%digit-cell{
+    text-align: center;
+    background-clip: padding-box;
 		width: $basic-cell-size;
     height: $basic-cell-size;
 		border: solid black 2px;


### PR DESCRIPTION
- increase min-hight of the risk popover to always show all content
- remove oversized border on legend of risk popover, add borders to cells
- remove border on 'consequence' label on risk popover.
- center align table items on risk popover
- bug: likelihood / consequence switching buttons not working on FF 60
  fix: function was relying on an implicit event argument, removed this and passed the name of the table to show instead.
- bug: risk matrix cell borders not showing
  fix: add background-clip: padding-box