### PR TITLE
added acronym polish

### DIFF
--- a/src/pages/criteria/criteria.scss
+++ b/src/pages/criteria/criteria.scss
@@ -49,6 +49,15 @@ page-criteria {
         margin-left:20px;
         margin-top:10px;
     }
+    .acronymHere {
+        color: #305194;
+        &:hover {
+          // text-decoration: underline;
+          font-style: italic;
+          // border: .5px solid #305194;
+          // padding: 1px;
+        }
+    }
     .navigate-links {
       color: blue;
       cursor: pointer;

--- a/src/pages/questions/questions.scss
+++ b/src/pages/questions/questions.scss
@@ -264,7 +264,13 @@ $input-border:#dcdcdc;
         padding: 10px;
     }
     .acronymHere {
-        color: gray;
+        color: #305194;
+        &:hover {
+          // text-decoration: underline;
+          font-style: italic;
+          // border: .5px solid #305194;
+          // padding: 1px;
+        }
     }
 
   }


### PR DESCRIPTION
all acronyms are blue (from docent guide) and on hover they turn italic
i think italic is better than underline because it signifies they are important without looking too much like links
on questions page in the explanation text and the criteria page