### PR TITLE
BugFix: Updating typescript to 2.9+ to eliminate html2canvas type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@angular/cli": "^6.0.8",
     "@ionic/app-scripts": "^3.2.4",
     "cypress": "^4.1.0",
-    "typescript": "2.7.2"
+    "typescript": "^2.*"
   },
   "description": "An Ionic project",
   "cordova": {


### PR DESCRIPTION
- Upgrading typescript version to newest 2.* to account for html2canvas error in package.json