### PR TITLE
fix the Start New Assessment bug

### DIFF
--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -69,7 +69,7 @@ export class HomePage implements OnInit {
 	  let loading = await this.loadingCtrl.create({
 		  spinner: 'crescent',
 		  message: 'Assessment Loading In, Please Wait',
-		  // dismissOnPageChange: true
+		  duration: 1000 
 	  });
 
 	  await loading.present();
@@ -104,9 +104,9 @@ export class HomePage implements OnInit {
             .then( d => {
               console.log(d);
 
-              // var assessmentId = d.data.createAssessment._id;
-              // this.sendEmailsToTeamMembers(assessmentId);
-              // this.startAssessment(assessmentId);
+              var assessmentId = d.data.createAssessment._id;
+              this.sendEmailsToTeamMembers(assessmentId);
+              this.startAssessment(assessmentId);
 
             })
             .catch(e => {

--- a/src/app/pages/questions/questions.page.scss
+++ b/src/app/pages/questions/questions.page.scss
@@ -495,7 +495,8 @@ $arrow-width: 1em;
 
         .mmp-summary {
           margin-left: 1vw;
-          height: 400px;
+          height: 200px;
+          width: 95%;
         }
       }
 


### PR DESCRIPTION
When user would click start new assessment, the 'Assessment loading' popover would endlessly be spinning, it now correctly goes to the questions page and into the assessment.

Also fixed the sizing for the MMP summary box